### PR TITLE
Fix spelling of cmpAnnRectsByScore to cmpAnnoRectsByScore to match wh…

### DIFF
--- a/utils/annolist/AnnotationLib.py
+++ b/utils/annolist/AnnotationLib.py
@@ -30,7 +30,7 @@ except ImportError:
 ################################################
 
 
-def cmpAnnRectsByScore(r1, r2):
+def cmpAnnoRectsByScore(r1, r2):
     return cmp(r1.score, r2.score)
 
 def cmpAnnoRectsByScoreDescending(r1, r2):


### PR DESCRIPTION
The sort by score method is able to sort based on cmpAnnoRectsByScore but the actual method is named cmpAnnRectsByScore. I checked that no method with this name is ever called and the reference in the sortByScore method does not exist so I renamed the method so match what's in sortByScore.