### PR TITLE
Changes in __setitem__ method of Annolist class 

### DIFF
--- a/utils/annolist/AnnotationLib.py
+++ b/utils/annolist/AnnotationLib.py
@@ -134,7 +134,8 @@ class AnnoList(MutableSequence):
         del self._list[ii]
 
     def __setitem__(self, ii, val):
-        return self._list[ii] = val
+        self._list[ii] = val
+        return self._list[ii]
 
     def __str__(self):
         return self.__repr__()

--- a/utils/annolist/AnnotationLib.py
+++ b/utils/annolist/AnnotationLib.py
@@ -134,7 +134,7 @@ class AnnoList(MutableSequence):
         del self._list[ii]
 
     def __setitem__(self, ii, val):
-        return self._list[ii]
+        return self._list[ii] = val
 
     def __str__(self):
         return self.__repr__()


### PR DESCRIPTION
Earlier the __setitem__ method was just returning the value from the list and the new **val** argument was not used.

Considering __setitem__ method should alter the old value of the list to the given new value at the specified index.

~~~~
 def __setitem__(self, ii, val):
         self._list[ii] = val
         return self._list[ii]
~~~~